### PR TITLE
Add flag to skip adding repos in case of pre-configured private repos

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,4 @@ docker_daemon_json:
 nvidia_docker_repo_base_url: "https://nvidia.github.io/nvidia-docker"
 nvidia_docker_repo_gpg_url: "{{ nvidia_docker_repo_base_url }}/gpgkey"
 nvidia_docker_wrapper_url: https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker
+nvidia_docker_add_repo: true

--- a/tasks/redhat-pre-install.yml
+++ b/tasks/redhat-pre-install.yml
@@ -14,6 +14,7 @@
     mode: 0644
     owner: root
     group: root
+  when: nvidia_docker_add_repo
 
 - name: install packages
   yum:

--- a/tasks/ubuntu-pre-install.yml
+++ b/tasks/ubuntu-pre-install.yml
@@ -12,6 +12,7 @@
   apt_key:
     url: "{{ nvidia_docker_repo_gpg_url }}"
     state: present
+  when: nvidia_docker_add_repo
 
 - name: add repo
   get_url:
@@ -20,6 +21,7 @@
     mode: 0644
     owner: root
     group: root
+  when: nvidia_docker_add_repo
 
 - name: install packages
   apt:


### PR DESCRIPTION
When running in environments that have a private or different repository already configured for nvidia-docker (such as a secure air gapped datacenter) we may want the ability to skip updating the repo file.

It may also be useful to allow the user to set a single variable for the repo url instead of hardcoding the path with multiple variables as in `"{{ nvidia_docker_repo_base_url }}/{{ _rhel_repo_dist_name }}/{{ _rhel_repo_file_name }}"`. That would probably be another PR.