### PR TITLE
Generate name of OS distribution from /etc/os-release

### DIFF
--- a/files/etc/ansible/facts.d/nv_os_release.fact
+++ b/files/etc/ansible/facts.d/nv_os_release.fact
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# The URL for the nvidia-docker repository depends on the Linux distribution
+# name and version, according to the contents of /etc/os-release:
+#
+#  distribution=$(. /etc/os-release;echo $ID_VERSION_ID)
+#  url="https://nvidia.github.io/nvidia-docker/${distribution}/"
+#
+# Unfortunately, the results of this particular check aren't found in the
+# existing Ansible facts, so we'll define a custom fact to get this
+# distribution name.
+
+set -eu
+
+source /etc/os-release
+
+nv_os_release="${ID}${VERSION_ID}"
+
+cat <<EOF
+{
+  "nv_os_release": "${nv_os_release}"
+}
+EOF

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,22 @@
 ---
+- name: ensure facts directory exists
+  file:
+    path: "/etc/ansible/facts.d"
+    state: directory
+    owner: "root"
+    group: "root"
+
+- name: setup custom facts
+  copy:
+    src: "etc/ansible/facts.d/nv_os_release.fact"
+    dest: "/etc/ansible/facts.d/nv_os_release.fact"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+
+- name: re-gather facts
+  setup:
+          
 - name: check distro
   fail:
     msg: "distro {{ ansible_facts['distribution'] }} not supported"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
     mode: "0755"
 
 - name: re-gather facts
-  setup:
+  setup: filter=ansible_local
           
 - name: check distro
   fail:

--- a/tasks/redhat-pre-install.yml
+++ b/tasks/redhat-pre-install.yml
@@ -9,7 +9,7 @@
 
 - name: add repo
   get_url:
-    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release'] }}/{{ _rhel_repo_file_name }}"
+    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release']['nv_os_release'] }}/{{ _rhel_repo_file_name }}"
     dest: "{{ _rhel_repo_file_path }}"
     mode: 0644
     owner: root

--- a/tasks/redhat-pre-install.yml
+++ b/tasks/redhat-pre-install.yml
@@ -9,7 +9,7 @@
 
 - name: add repo
   get_url:
-    url: "{{ nvidia_docker_repo_base_url }}/{{ nv_os_release }}/{{ _rhel_repo_file_name }}"
+    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release'] }}/{{ _rhel_repo_file_name }}"
     dest: "{{ _rhel_repo_file_path }}"
     mode: 0644
     owner: root

--- a/tasks/redhat-pre-install.yml
+++ b/tasks/redhat-pre-install.yml
@@ -9,7 +9,7 @@
 
 - name: add repo
   get_url:
-    url: "{{ nvidia_docker_repo_base_url }}/{{ _rhel_repo_dist_name }}/{{ _rhel_repo_file_name }}"
+    url: "{{ nvidia_docker_repo_base_url }}/{{ nv_os_release }}/{{ _rhel_repo_file_name }}"
     dest: "{{ _rhel_repo_file_path }}"
     mode: 0644
     owner: root

--- a/tasks/ubuntu-pre-install.yml
+++ b/tasks/ubuntu-pre-install.yml
@@ -16,7 +16,7 @@
 
 - name: add repo
   get_url:
-    url: "{{ nvidia_docker_repo_base_url }}/{{ nv_os_release }}/{{ _ubuntu_repo_file_name }}"
+    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release'] }}/{{ _ubuntu_repo_file_name }}"
     dest: "{{ _ubuntu_repo_file_path }}"
     mode: 0644
     owner: root

--- a/tasks/ubuntu-pre-install.yml
+++ b/tasks/ubuntu-pre-install.yml
@@ -16,7 +16,7 @@
 
 - name: add repo
   get_url:
-    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release'] }}/{{ _ubuntu_repo_file_name }}"
+    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release']['nv_os_release'] }}/{{ _ubuntu_repo_file_name }}"
     dest: "{{ _ubuntu_repo_file_path }}"
     mode: 0644
     owner: root

--- a/tasks/ubuntu-pre-install.yml
+++ b/tasks/ubuntu-pre-install.yml
@@ -16,7 +16,7 @@
 
 - name: add repo
   get_url:
-    url: "{{ nvidia_docker_repo_base_url }}/{{ _ubuntu_repo_dist_name }}/{{ _ubuntu_repo_file_name }}"
+    url: "{{ nvidia_docker_repo_base_url }}/{{ nv_os_release }}/{{ _ubuntu_repo_file_name }}"
     dest: "{{ _ubuntu_repo_file_path }}"
     mode: 0644
     owner: root

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,5 @@
-_ubuntu_repo_dist_name: "{{ ansible_distribution | lower }}{{ ansible_distribution_version }}"
 _ubuntu_repo_file_name: "nvidia-docker.list"
 _ubuntu_repo_file_path: "/etc/apt/sources.list.d/{{ _ubuntu_repo_file_name }}"
 
-_rhel_repo_dist_name: "{{ ansible_distribution | lower }}{{ ansible_distribution_major_version }}"
 _rhel_repo_file_name: "nvidia-docker.repo"
 _rhel_repo_file_path: "/etc/yum.repos.d/{{ _rhel_repo_file_name }}"


### PR DESCRIPTION
This PR generates the OS distribution name by building a custom fact from `/etc/os-release`. This method for getting the right distribution name is [documented in the README for nvidia-docker](https://github.com/NVIDIA/nvidia-docker/blob/master/README.md#quickstart).

The old method, which used builtin Ansible facts, worked correctly on Ubuntu and CentOS but failed on RHEL. On RHEL 7 systems, it generated distribution names that look like `redhat7` instead of the expected `rhel7.7`. This generated the wrong URL for the repository and caused the install to fail.

Before this change, attempting to use this role on RHEL 7 resulted in an error that looks like this on the `nvidia.nvidia_docker : add repo` task:

```
fatal: [rhel-vm]: FAILED! => changed=false 
  dest: /etc/yum.repos.d/nvidia-docker.repo
  elapsed: 0
  msg: Request failed
  response: 'HTTP Error 404: Not Found'
  status_code: 404
  url: https://nvidia.github.io/nvidia-docker/redhat7/nvidia-docker.repo
```

# Test plan

Using a VM on each of Ubuntu 18.04, CentOS 7, and RHEL 7.7, I used the following procedure:

1. Using a fresh [DeepOps](https://github.com/NVIDIA/deepops) checkout, modified the `requirements.yml` file to use my modified nvidia-docker role:
    ```
    +- src: https://github.com/ajdecon/ansible-role-nvidia-docker.git
    +  version: '42f3706531da6005d61649e130e7d10fed347c1a'
    +  name: ajdecon.nvidia_docker
    ```
1. Modified `playbooks/nvidia-docker.yml` to reference `ajdecon.nvidia_docker` instead of `nvidia.nvidia_docker`
1. Built a fresh VM of the target distribution (either using Vagrant or from an ISO), and set the Ansible inventory to point to this VM
1. Ran `ansible-playbook playbooks/docker.yml` to install docker
1. Ran `ansible-playbook playbooks/nvidia-docker.yml` to run the role under test.

In each case, the result is a successful nvidia-docker install.