### PR TITLE
Add var to allow skipping reload of Docker daemon

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,4 @@ nvidia_docker_repo_base_url: "https://nvidia.github.io/nvidia-docker"
 nvidia_docker_repo_gpg_url: "{{ nvidia_docker_repo_base_url }}/gpgkey"
 nvidia_docker_wrapper_url: https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker
 nvidia_docker_add_repo: true
+nvidia_docker_skip_docker_reload: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   service:
     name: docker
     state: reloaded
+  when: not nvidia_docker_skip_docker_reload


### PR DESCRIPTION
Needed when installing the nvidia container runtime without docker for use with rootless docker. See: https://github.com/NVIDIA/deepops/pull/824