### PR TITLE
Directly set package repository URLs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,8 +20,23 @@ docker_daemon_json:
       hard: 67108864
       soft: 67108864
 
-nvidia_docker_repo_base_url: "https://nvidia.github.io/nvidia-docker"
-nvidia_docker_repo_gpg_url: "{{ nvidia_docker_repo_base_url }}/gpgkey"
+nvidia_docker_repo_base_url: "https://nvidia.github.io"
+nvidia_docker_repo_gpg_url: "{{ nvidia_docker_repo_base_url }}/nvidia-docker/gpgkey"
 nvidia_docker_wrapper_url: https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker
 nvidia_docker_add_repo: true
 nvidia_docker_skip_docker_reload: false
+
+# Ubuntu
+nvidia_docker_apt_repo_lines:
+- "deb {{ nvidia_docker_repo_base_url }}/nvidia-docker/{{ ansible_local['nv_os_release']['nv_os_release'] }}/$(ARCH) /"
+- "deb {{ nvidia_docker_repo_base_url }}/libnvidia-container/stable/{{ ansible_local['nv_os_release']['nv_os_release'] }}/$(ARCH) /"
+- "deb {{ nvidia_docker_repo_base_url }}/nvidia-container-runtime/stable/{{ ansible_local['nv_os_release']['nv_os_release'] }}/$(ARCH) /"
+
+# RedHat
+nvidia_docker_yum_repos:
+- name: "libnvidia-container"
+  baseurl: "{{ nvidia_docker_repo_base_url }}/libnvidia-container/{{ ansible_local['nv_os_release']['nv_os_release'] }}/$basearch"
+- name: "nvidia-container-runtime"
+  baseurl: "{{ nvidia_docker_repo_base_url }}/nvidia-container-runtime/{{ ansible_local['nv_os_release']['nv_os_release'] }}/$basearch"
+- name: "nvidia-docker"
+  baseurl: "{{ nvidia_docker_repo_base_url }}/nvidia-docker/{{ ansible_local['nv_os_release']['nv_os_release'] }}/$basearch"

--- a/tasks/redhat-pre-install.yml
+++ b/tasks/redhat-pre-install.yml
@@ -8,15 +8,14 @@
     autoremove: yes
 
 - name: add repo
-  get_url:
-    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release']['nv_os_release'] }}/{{ _rhel_repo_file_name }}"
-    dest: "{{ _rhel_repo_file_path }}"
-    mode: 0644
-    owner: root
-    group: root
+  yum_repository:
+    name: "{{ item.name }}"
+    description: "{{ item.name }}"
+    baseurl: "{{ item.baseurl }}"
+    gpgkey: "{{ nvidia_docker_repo_gpg_url }}"
   when: nvidia_docker_add_repo
   environment: "{{proxy_env if proxy_env is defined else {}}}"
-
+  with_items: "{{ nvidia_docker_yum_repos }}"
 
 - name: install packages
   yum:

--- a/tasks/ubuntu-pre-install.yml
+++ b/tasks/ubuntu-pre-install.yml
@@ -16,14 +16,12 @@
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 
 - name: add repo
-  get_url:
-    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release']['nv_os_release'] }}/{{ _ubuntu_repo_file_name }}"
-    dest: "{{ _ubuntu_repo_file_path }}"
-    mode: 0644
-    owner: root
-    group: root
+  apt_repository:
+    repo: "{{ item }}"
+    state: "present"
   when: nvidia_docker_add_repo
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  with_items: "{{ nvidia_docker_apt_repo_lines }}"
 
 - name: install packages
   apt:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,0 @@
-_ubuntu_repo_file_name: "nvidia-docker.list"
-_ubuntu_repo_file_path: "/etc/apt/sources.list.d/{{ _ubuntu_repo_file_name }}"
-
-_rhel_repo_file_name: "nvidia-docker.repo"
-_rhel_repo_file_path: "/etc/yum.repos.d/{{ _rhel_repo_file_name }}"


### PR DESCRIPTION
The current method for setting up package repositories relies on
downloading the repo config files from nvidia.github.io.

However, that means this role can't be easily used if the user is
installing these packages from an alternate (possibly local) mirror.

This PR replaces the config file download with a workflow where the repo
configuration is more directly managed, making it easier to specify
alternate URLs.