### PR TITLE
Restart docker rather than reloading

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,7 @@ nvidia_docker_repo_gpg_url: "{{ nvidia_docker_repo_base_url }}/gpgkey"
 nvidia_docker_wrapper_url: https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker
 nvidia_docker_add_repo: true
 nvidia_docker_skip_docker_reload: false
+
+# Replacing the reload var with the restart var, using this by default for
+# backward compatibility
+nvidia_docker_skip_docker_restart: "{{ nvidia_docker_skip_docker_reload }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: reload docker
+- name: restart docker
   service:
     name: docker
-    state: reloaded
-  when: not nvidia_docker_skip_docker_reload
+    state: restarted
+  when: not nvidia_docker_skip_docker_restart

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: reload docker
+  notify: restart docker
 
 # We could use the "nvidia-docker2" package to install this wrapper for us.
 # Instead, we grab the wrapper directly to avoid packaging issues stemming from

--- a/tasks/redhat-pre-install.yml
+++ b/tasks/redhat-pre-install.yml
@@ -23,5 +23,5 @@
     name: nvidia-container-runtime
     state: present
     update_cache: yes
-  notify: reload docker
+  notify: restart docker
   environment: "{{proxy_env if proxy_env is defined else {}}}"

--- a/tasks/ubuntu-pre-install.yml
+++ b/tasks/ubuntu-pre-install.yml
@@ -30,5 +30,5 @@
     name: nvidia-container-runtime
     state: present
     update_cache: yes
-  notify: reload docker
+  notify: restart docker
   environment: "{{proxy_env if proxy_env is defined else {}}}"


### PR DESCRIPTION
Reloading the docker config is not always resulting in the nvidia container runtime becoming available, restart the daemon instead