### PR TITLE
moving ubuntu support to generic debian support + become all needed tasks

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,10 @@ galaxy_info:
       versions:
         - 'xenial'
         - 'bionic'
+    - name: Debian
+      versions:
+        - 'buster'
+        - 'stretch'
     - name: EL
       versions:
         - '7'

--- a/tasks/debian-pre-install.yml
+++ b/tasks/debian-pre-install.yml
@@ -7,11 +7,13 @@
     state: absent
     autoremove: yes
     purge: yes
+  become: true
 
 - name: add key
   apt_key:
     url: "{{ nvidia_docker_repo_gpg_url }}"
     state: present
+  become: true
   when: nvidia_docker_add_repo
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 
@@ -22,6 +24,7 @@
     mode: 0644
     owner: root
     group: root
+  become: true
   when: nvidia_docker_add_repo
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 
@@ -30,5 +33,6 @@
     name: nvidia-container-runtime
     state: present
     update_cache: yes
+  become: true
   notify: restart docker
   environment: "{{proxy_env if proxy_env is defined else {}}}"

--- a/tasks/debian-pre-install.yml
+++ b/tasks/debian-pre-install.yml
@@ -19,7 +19,7 @@
 
 - name: add repo
   get_url:
-    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release']['nv_os_release'] }}/{{ _debian_repo_file_name }}"
+    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release']['nv_os_release'] | default(nv_os_release) }}/{{ _debian_repo_file_name }}"
     dest: "{{ _debian_repo_file_path }}"
     mode: 0644
     owner: root

--- a/tasks/debian-pre-install.yml
+++ b/tasks/debian-pre-install.yml
@@ -17,8 +17,8 @@
 
 - name: add repo
   get_url:
-    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release']['nv_os_release'] }}/{{ _ubuntu_repo_file_name }}"
-    dest: "{{ _ubuntu_repo_file_path }}"
+    url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release']['nv_os_release'] }}/{{ _debian_repo_file_name }}"
+    dest: "{{ _debian_repo_file_path }}"
     mode: 0644
     owner: root
     group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
     owner: "root"
     group: "root"
     mode: "0755"
+  when: nv_os_release is undefined
   become: true
 
 - name: re-gather facts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,11 +20,11 @@
 - name: check distro
   fail:
     msg: "distro {{ ansible_facts['distribution'] }} not supported"
-  when: ansible_facts['distribution'] != 'Ubuntu' and ansible_os_family != 'RedHat'
+  when: ansible_os_family != 'Debian' and ansible_os_family != 'RedHat'
 
-- name: ubuntu pre-install tasks
-  include_tasks: ubuntu-pre-install.yml
-  when: ansible_distribution == 'Ubuntu'
+- name: debian pre-install tasks
+  include_tasks: debian-pre-install.yml
+  when: ansible_os_family == 'Debian'
 
 - name: redhat family pre-install tasks
   include_tasks: redhat-pre-install.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     state: directory
     owner: "root"
     group: "root"
+  become: true
 
 - name: setup custom facts
   copy:
@@ -13,6 +14,7 @@
     owner: "root"
     group: "root"
     mode: "0755"
+  become: true
 
 - name: re-gather facts
   setup: filter=ansible_local
@@ -35,6 +37,7 @@
     path: /etc/docker
     state: directory
     mode: '0755'
+  become: true
 
 - name: set docker daemon configuration
   copy:
@@ -43,6 +46,7 @@
     owner: root
     group: root
     mode: 0644
+  become: true
   notify: restart docker
 
 # We could use the "nvidia-docker2" package to install this wrapper for us.
@@ -55,5 +59,6 @@
     mode: 0755
     owner: root
     group: root
+  become: true
   environment: "{{proxy_env if proxy_env is defined else {}}}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
-_ubuntu_repo_file_name: "nvidia-docker.list"
-_ubuntu_repo_file_path: "/etc/apt/sources.list.d/{{ _ubuntu_repo_file_name }}"
+_debian_repo_file_name: "nvidia-docker.list"
+_debian_repo_file_path: "/etc/apt/sources.list.d/{{ _debian_repo_file_name }}"
 
 _rhel_repo_file_name: "nvidia-docker.repo"
 _rhel_repo_file_path: "/etc/yum.repos.d/{{ _rhel_repo_file_name }}"


### PR DESCRIPTION
Since the docs for the [nvidia docker container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker) says that it supports Ubuntu LTS & Debian, is there a reason why this role is targeted towards specifically Ubuntu?

I think the changes that I made should work for a generic Debian distro, similarly to how your already RHEL compatibility is configured. Full disclosure I haven't tested the changes to the role, because I don't have a Debian'ish box right now with an Nvidia GPU :sweat_smile: . Technically running it against Ubuntu should count as testing it though :upside_down_face: .

I also added an additional an optional override for the nv_os_version variable, so that way if someone is on like an Ubuntu mint version then the could specify a var of `nv_os_release: ubuntu20.04` since they share the same base. This would treat the install as an ubuntu 20.04 machine then.

Let me know if there is something I should change :slightly_smiling_face: or any concerns you have.

P.S. I also added become to all the relevant tasks, because if you do something like `include_role` and your overall playbook isn't executing as root ( w/become ) then this role will fail. You also can't add a become to `include_role` to only elevate that role.

![image](https://user-images.githubusercontent.com/10230166/127778350-b595fe3a-6e3c-4ca8-94c2-bdbff2bbacab.png)
