### PR TITLE
Add flag to deactivate nvidia-docker wrapper installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,7 @@ nvidia_docker_repo_base_url: "https://nvidia.github.io/nvidia-docker"
 nvidia_docker_repo_gpg_url: "{{ nvidia_docker_repo_base_url }}/gpgkey"
 nvidia_docker_wrapper_url: https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker
 nvidia_docker_add_repo: true
+nvidia_docker_install_wrapper: true
 nvidia_docker_skip_docker_reload: false
 
 # Replacing the reload var with the restart var, using this by default for

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,4 +56,5 @@
     owner: root
     group: root
   environment: "{{proxy_env if proxy_env is defined else {}}}"
+  when: nvidia_docker_install_wrapper
 


### PR DESCRIPTION
Allow skipping of the `nvidia-docker` wrapper installation which rely on an external and non-packaged dependency