### PR TITLE
fix: Update role with ansible-lint recommendation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,8 @@
 ---
-- name: restart docker
-  systemd:
+- name: Restart docker
+  ansible.builtin.systemd:
     name: docker
-    daemon_reload: yes
+    daemon_reload: true
     state: restarted
   when: not nvidia_docker_skip_docker_restart
+  become: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   company: NVIDIA
   description: Install nvidia-docker
   license: 3-Clause BSD
-  min_ansible_version: 2.0
+  min_ansible_version: "2.0"
 
   platforms:
     - name: Ubuntu

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,60 +1,67 @@
 ---
-- name: ensure facts directory exists
-  file:
+- name: Ensure facts directory exists
+  ansible.builtin.file:
     path: "/etc/ansible/facts.d"
     state: directory
     owner: "root"
     group: "root"
+    mode: "755"
+  become: true
 
-- name: setup custom facts
-  copy:
+- name: Setup custom facts
+  ansible.builtin.copy:
     src: "etc/ansible/facts.d/nv_os_release.fact"
     dest: "/etc/ansible/facts.d/nv_os_release.fact"
     owner: "root"
     group: "root"
     mode: "0755"
+  become: true
 
-- name: re-gather facts
-  setup: filter=ansible_local
-          
-- name: check distro
-  fail:
+- name: Re-gather facts
+  ansible.builtin.setup:
+    filter:
+      - ansible_local
+
+- name: Check distro
+  ansible.builtin.fail:
     msg: "distro {{ ansible_facts['distribution'] }} not supported"
   when: ansible_facts['distribution'] != 'Ubuntu' and ansible_os_family != 'RedHat'
 
-- name: ubuntu pre-install tasks
-  include_tasks: ubuntu-pre-install.yml
+- name: Ubuntu pre-install tasks
+  ansible.builtin.include_tasks: ubuntu-pre-install.yml
   when: ansible_distribution == 'Ubuntu'
 
-- name: redhat family pre-install tasks
-  include_tasks: redhat-pre-install.yml
+- name: Redhat family pre-install tasks
+  ansible.builtin.include_tasks: redhat-pre-install.yml
   when: ansible_os_family == 'RedHat'
 
-- name: create /etc/docker
-  file:
+- name: Create /etc/docker
+  ansible.builtin.file:
     path: /etc/docker
     state: directory
     mode: '0755'
+  become: true
 
-- name: set docker daemon configuration
-  copy:
+- name: Set docker daemon configuration
+  ansible.builtin.copy:
     content: "{{ docker_daemon_json | to_nice_json }}"
     dest: /etc/docker/daemon.json
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   notify: restart docker
+  become: true
 
 # We could use the "nvidia-docker2" package to install this wrapper for us.
 # Instead, we grab the wrapper directly to avoid packaging issues stemming from
 #   docker version pinning in the nvidia-docker2 package.
-- name: grab nvidia-docker wrapper
-  get_url:
+- name: Grab nvidia-docker wrapper
+  ansible.builtin.get_url:
     url: "{{ nvidia_docker_wrapper_url }}"
     dest: /usr/local/bin/nvidia-docker
-    mode: 0755
+    mode: "0755"
     owner: root
     group: root
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
   when: nvidia_docker_install_wrapper
-
+  become: true

--- a/tasks/redhat-pre-install.yml
+++ b/tasks/redhat-pre-install.yml
@@ -1,27 +1,27 @@
 ---
-- name: remove packages
-  yum:
+- name: Remove packages
+  ansible.builtin.yum:
     name:
       - nvidia-docker
       - nvidia-docker2
     state: absent
-    autoremove: yes
+    autoremove: true
 
-- name: add repo
-  get_url:
+- name: Add repo
+  ansible.builtin.get_url:
     url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release']['nv_os_release'] }}/{{ _rhel_repo_file_name }}"
     dest: "{{ _rhel_repo_file_path }}"
-    mode: 0644
+    mode: "0644"
     owner: root
     group: root
   when: nvidia_docker_add_repo
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
 
-- name: install packages
-  yum:
+- name: Install packages
+  ansible.builtin.yum:
     name: nvidia-container-runtime
     state: present
-    update_cache: yes
+    update_cache: true
   notify: restart docker
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"

--- a/tasks/ubuntu-pre-install.yml
+++ b/tasks/ubuntu-pre-install.yml
@@ -1,34 +1,37 @@
 ---
-- name: remove packages
-  apt:
+- name: Remove packages
+  ansible.builtin.apt:
     name:
       - nvidia-docker
       - nvidia-docker2
     state: absent
-    autoremove: yes
-    purge: yes
+    autoremove: true
+    purge: true
+  become: true
 
-- name: add key
-  apt_key:
+- name: Add key
+  ansible.builtin.apt_key:
     url: "{{ nvidia_docker_repo_gpg_url }}"
     state: present
   when: nvidia_docker_add_repo
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
-- name: add repo
-  get_url:
+- name: Add repo
+  ansible.builtin.get_url:
     url: "{{ nvidia_docker_repo_base_url }}/{{ ansible_local['nv_os_release']['nv_os_release'] }}/{{ _ubuntu_repo_file_name }}"
     dest: "{{ _ubuntu_repo_file_path }}"
-    mode: 0644
+    mode: "0644"
     owner: root
     group: root
   when: nvidia_docker_add_repo
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
+  become: true
 
-- name: install packages
-  apt:
+- name: Install packages
+  ansible.builtin.apt:
     name: nvidia-container-runtime
     state: present
-    update_cache: yes
+    update_cache: true
   notify: restart docker
-  environment: "{{proxy_env if proxy_env is defined else {}}}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
+  become: true

--- a/tasks/ubuntu-pre-install.yml
+++ b/tasks/ubuntu-pre-install.yml
@@ -15,6 +15,7 @@
     state: present
   when: nvidia_docker_add_repo
   environment: "{{ proxy_env if proxy_env is defined else {} }}"
+  become: true
 
 - name: Add repo
   ansible.builtin.get_url:
@@ -32,6 +33,6 @@
     name: nvidia-container-runtime
     state: present
     update_cache: true
-  notify: restart docker
+  notify: Restart docker
   environment: "{{ proxy_env if proxy_env is defined else {} }}"
   become: true


### PR DESCRIPTION
This change includes a few minor changes.

- Use ansible FQCN names over short names
- Added `become: true` on specific modules that required privilege. (Make it clear which module needs privilege escalation.)